### PR TITLE
bumped to version 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.curityVersion>2.4.0</project.curityVersion>
-        <project.slf4jVersion>1.7.22</project.slf4jVersion>
-        <kotlin.version>1.1.4-3</kotlin.version>
+        <project.curityVersion>4.4.0</project.curityVersion>
+        <project.slf4jVersion>1.7.25</project.slf4jVersion>
+        <kotlin.version>1.2.50</kotlin.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.curity.identityserver.plugin</groupId>
     <artifactId>identityserver.plugins.authenticators.freja-eid</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <name>Curity Verisec Authenticator</name>

--- a/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/authentication/RequestModel.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/authentication/RequestModel.kt
@@ -68,4 +68,5 @@ class PhoneRequestModel(request: Request) : Post()
 class WaitModel(request: Request) : Post()
 {
     val moveOn: Boolean = "true" == request.getFormParameterValueOrError("moveOn")
+    val cancel: Boolean = "true" == request.getFormParameterValueOrError("cancel")
 }

--- a/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/authentication/StartRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/authentication/StartRequestHandler.kt
@@ -32,7 +32,6 @@ import se.curity.identityserver.sdk.http.HttpRequest
 import se.curity.identityserver.sdk.http.HttpResponse
 import se.curity.identityserver.sdk.http.HttpStatus
 import se.curity.identityserver.sdk.http.RedirectStatusCode
-import se.curity.identityserver.sdk.service.Json
 import se.curity.identityserver.sdk.service.WebServiceClient
 import se.curity.identityserver.sdk.web.Request
 import se.curity.identityserver.sdk.web.Response
@@ -58,6 +57,7 @@ class StartRequestHandler(private val config: FrejaEidAuthenticatorPluginConfig,
     private val _userPreferencesManager = config.userPreferencesManager
     private val _httpClient = config.httpClient
     private val _relyingPartyId = config.relyingPartyId.orElse(null)
+    private val _emailAddressAttributeToReturn = Collections.singletonList(mapOf("attribute" to AttributesToReturn.EMAIL_ADDRESS))
 
     override fun preProcess(request: Request, response: Response): RequestModel
     {
@@ -196,11 +196,11 @@ class StartRequestHandler(private val config: FrejaEidAuthenticatorPluginConfig,
 
         if (_minRegistrationLevel == RegistrationLevel.BASIC && _attributesToReturn.contains(AttributesToReturn.EMAIL_ADDRESS))
         {
-            dataMap["attributesToReturn"] = Collections.singletonList(mapOf("attribute" to AttributesToReturn.EMAIL_ADDRESS))
+            dataMap["attributesToReturn"] = _emailAddressAttributeToReturn
         }
         else if (_attributesToReturn.isNotEmpty() && _minRegistrationLevel != RegistrationLevel.BASIC)
         {
-            dataMap["attributesToReturn"] = _attributesToReturn.map { mapOf("attribute" to it)}
+            dataMap["attributesToReturn"] = _attributesToReturn.map { mapOf("attribute" to it) }
         }
 
         return dataMap

--- a/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/authentication/StartRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/authentication/StartRequestHandler.kt
@@ -86,7 +86,7 @@ class StartRequestHandler(private val config: FrejaEidAuthenticatorPluginConfig,
     override fun get(requestModel: RequestModel, response: Response): Optional<AuthenticationResult> =
             if (authenticatedState.isAuthenticated)
             {
-                startAuthentication(requestModel, response)
+                startAuthentication(requestModel)
             }
             else
             {
@@ -94,9 +94,9 @@ class StartRequestHandler(private val config: FrejaEidAuthenticatorPluginConfig,
             }
 
     override fun post(requestModel: RequestModel, response: Response): Optional<AuthenticationResult> =
-            startAuthentication(requestModel, response)
+            startAuthentication(requestModel)
 
-    private fun startAuthentication(requestModel: RequestModel, response: Response): Optional<AuthenticationResult>
+    private fun startAuthentication(requestModel: RequestModel): Optional<AuthenticationResult>
     {
         val username = when
         {

--- a/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/authentication/StartRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/authentication/StartRequestHandler.kt
@@ -16,6 +16,7 @@
 
 package io.curity.identityserver.plugin.frejaeid.authentication
 
+import io.curity.identityserver.plugin.frejaeid.authentication.WaitRequestHandler.Companion.SESSION_AUTH_REF
 import io.curity.identityserver.plugin.frejaeid.config.AttributesToReturn
 import io.curity.identityserver.plugin.frejaeid.config.FrejaEidAuthenticatorPluginConfig
 import io.curity.identityserver.plugin.frejaeid.config.RegistrationLevel
@@ -31,7 +32,6 @@ import se.curity.identityserver.sdk.http.HttpRequest
 import se.curity.identityserver.sdk.http.HttpResponse
 import se.curity.identityserver.sdk.http.HttpStatus
 import se.curity.identityserver.sdk.http.RedirectStatusCode
-import se.curity.identityserver.sdk.service.ExceptionFactory
 import se.curity.identityserver.sdk.service.WebServiceClient
 import se.curity.identityserver.sdk.web.Request
 import se.curity.identityserver.sdk.web.Response
@@ -122,7 +122,7 @@ class StartRequestHandler(private val config: FrejaEidAuthenticatorPluginConfig,
 
         if (authRef != null)
         {
-            config.sessionManager.put(Attribute.of("authRef", authRef))
+            config.sessionManager.put(Attribute.of(SESSION_AUTH_REF, authRef))
 
             throw _exceptionFactory.redirectException(getWaitHandlerUrl(),
                     RedirectStatusCode.MOVED_TEMPORARILY, emptyMap(), false)

--- a/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/authentication/StartRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/authentication/StartRequestHandler.kt
@@ -32,6 +32,7 @@ import se.curity.identityserver.sdk.http.HttpRequest
 import se.curity.identityserver.sdk.http.HttpResponse
 import se.curity.identityserver.sdk.http.HttpStatus
 import se.curity.identityserver.sdk.http.RedirectStatusCode
+import se.curity.identityserver.sdk.service.Json
 import se.curity.identityserver.sdk.service.WebServiceClient
 import se.curity.identityserver.sdk.web.Request
 import se.curity.identityserver.sdk.web.Response
@@ -169,7 +170,7 @@ class StartRequestHandler(private val config: FrejaEidAuthenticatorPluginConfig,
             val value = when
             {
                 it.value is String -> "\"" + it.value + "\""
-                else -> it.value
+                else -> _json.toJson(it.value)
             }
             "\"" + it.key + "\"" + ":" + value
         }.joinToString() + "}"
@@ -195,12 +196,11 @@ class StartRequestHandler(private val config: FrejaEidAuthenticatorPluginConfig,
 
         if (_minRegistrationLevel == RegistrationLevel.BASIC && _attributesToReturn.contains(AttributesToReturn.EMAIL_ADDRESS))
         {
-            dataMap["attributesToReturn"] = Collections.singletonList(
-                    "{\"attribute\":\"" + AttributesToReturn.EMAIL_ADDRESS + "\"}")
+            dataMap["attributesToReturn"] = Collections.singletonList(mapOf("attribute" to AttributesToReturn.EMAIL_ADDRESS))
         }
         else if (_attributesToReturn.isNotEmpty() && _minRegistrationLevel != RegistrationLevel.BASIC)
         {
-            dataMap["attributesToReturn"] = _attributesToReturn.map { "{\"attribute\":\"$it\"}" }
+            dataMap["attributesToReturn"] = _attributesToReturn.map { mapOf("attribute" to it)}
         }
 
         return dataMap

--- a/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/authentication/WaitRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/authentication/WaitRequestHandler.kt
@@ -294,9 +294,8 @@ class WaitRequestHandler(private val config: FrejaEidAuthenticatorPluginConfig) 
     {
         val authRef = _sessionManager.get(SESSION_AUTH_REF)?.let {
             _json.toJson(Collections.singletonMap("authRef", it.value)).toByteArray()
-        }
-                ?: throw config.exceptionFactory.badRequestException(ErrorCode.INVALID_SERVER_STATE,
-                        "authRef cannot be null")
+        } ?: throw config.exceptionFactory.badRequestException(ErrorCode.INVALID_SERVER_STATE,
+                "authRef cannot be null")
         _sessionManager.remove(SESSION_AUTH_REF)
         val authResultRequest = "cancelAuthRequest=${Base64.getEncoder().encodeToString(authRef)}"
         val requestBody = _relyingPartyId?.let { "$authResultRequest&relyingPartyId=$it" } ?: authResultRequest

--- a/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/config/FrejaEidAuthenticatorPluginConfig.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/config/FrejaEidAuthenticatorPluginConfig.kt
@@ -29,6 +29,9 @@ interface FrejaEidAuthenticatorPluginConfig : Configuration
     
     @get:Description("The environment to use for authentication")
     val environment: PredefinedEnvironment
+
+    @get:Description("Minimum required registration level of the user")
+    val minimumRegistrationLevel: RegistrationLevel
     
     @get:Description("User Identifier Type")
     val userInfoType: UserInfoType
@@ -47,6 +50,8 @@ interface FrejaEidAuthenticatorPluginConfig : Configuration
     val json: Json
     
     val authenticatorInformationProvider: AuthenticatorInformationProvider
+
+    val attributesToReturn: List<AttributesToReturn>
 }
 
 enum class PredefinedEnvironment
@@ -67,8 +72,26 @@ enum class PredefinedEnvironment
     }
 }
 
+enum class AttributesToReturn
+{
+    BASIC_USER_INFO,
+    EMAIL_ADDRESS,
+    DATE_OF_BIRTH,
+    SSN,
+    CUSTOM_IDENTIFIER,
+    RELYING_PARTY_USER_ID
+}
+
+enum class RegistrationLevel
+{
+    BASIC,
+    EXTENDED,
+    PLUS
+}
+
 enum class UserInfoType
 {
     EMAIL,
-    SSN
+    SSN,
+    PHONE
 }

--- a/src/main/resources/messages/en/authenticator/freja-eid/authenticate/messages
+++ b/src/main/resources/messages/en/authenticator/freja-eid/authenticate/messages
@@ -15,6 +15,26 @@
 #
 
 meta.title=Freja eID
-validation.error.username.required=You have to enter your username
-validation.error.email.required=You have to enter your email
+view.title=Login
+view.email.label=Email
+view.email.description=Please enter your email
+view.email.placeholder=user@example.com
+view.ssn.label=Personal Number
+view.ssn.description=Please enter your personal number
+view.ssn.placeholder=YYYYMMDDXXXX
+view.phone.label=Phone Number
+view.phone.description=Please enter your phone number
+view.phone.placeholder=+467XXXXXXXX
+view.submit=Next
+
 wait.view.authTimeout=Authentication did not take place within the allowable time limit.
+wait.view.description=Please open Freja eID mobile app and complete the authentication
+wait.view.title=Waiting for Freja eID
+
+validation.error.phone.invalid=The phone number you have entered is invalid
+validation.error.phone.required=You have to enter your phone number
+validation.error.email.invalid=The email you have entered is invalid
+validation.error.email.required=You have to enter your email
+validation.error.ssn.invalid=The personal number you have entered is invalid
+validation.error.ssn.required=You have to enter your personal number
+too.many.attempts=There were too many attempts to authenticate recently, please try again in a few minutes

--- a/src/main/resources/messages/en/authenticator/freja-eid/authenticate/messages
+++ b/src/main/resources/messages/en/authenticator/freja-eid/authenticate/messages
@@ -30,6 +30,8 @@ view.submit=Next
 wait.view.authTimeout=Authentication did not take place within the allowable time limit.
 wait.view.description=Please open Freja eID mobile app and complete the authentication
 wait.view.title=Waiting for Freja eID
+wait.back=Back
+wait.cancel=Cancel
 
 validation.error.phone.invalid=The phone number you have entered is invalid
 validation.error.phone.required=You have to enter your phone number

--- a/src/main/resources/messages/sv/authenticator/freja-eid/authenticate/messages
+++ b/src/main/resources/messages/sv/authenticator/freja-eid/authenticate/messages
@@ -30,6 +30,8 @@ view.submit=Nästa
 wait.view.authTimeout=Inloggningsförfrågan tog för lång tid att utföra
 wait.view.description=Öppna Freja eID-app för att slutföra inloggnignen
 wait.view.title=Väntar på Freja eID
+wait.back=Tillbaka
+wait.cancel=Avbryt
 
 validation.error.phone.invalid=Telefonnummret du angett är ogiltigt
 validation.error.phone.required=Du måste ange ditt telefonnummer

--- a/src/main/resources/messages/sv/authenticator/freja-eid/authenticate/messages
+++ b/src/main/resources/messages/sv/authenticator/freja-eid/authenticate/messages
@@ -1,0 +1,42 @@
+#
+#  Copyright 2019 Curity AB
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+meta.title=Freja eID
+view.title=Logga in
+view.email.label=E-post
+view.email.description=Var god ange din in e-postadress
+view.email.placeholder=user@example.com
+view.ssn.label=Personnummer
+view.ssn.description=Var god ange ditt personnummer
+view.ssn.placeholder=ÅÅÅÅMMDDXXXX
+view.phone.label=Telefonnummer
+view.phone.description=Var god ange ditt telefonnummer
+view.phone.placeholder=+467XXXXXXXX
+view.submit=Nästa
+
+wait.view.authTimeout=Inloggningsförfrågan tog för lång tid att utföra
+wait.view.description=Öppna Freja eID-app för att slutföra inloggnignen
+wait.view.title=Väntar på Freja eID
+
+validation.error.phone.invalid=Telefonnummret du angett är ogiltigt
+validation.error.phone.required=Du måste ange ditt telefonnummer
+validation.error.email.invalid=E-postadressen du angett är ogiltig
+validation.error.email.required=Du måste ange din e-post
+validation.error.ssn.invalid=Personnummret du angett är ogiltigt
+validation.error.ssn.required=Du måste ange ditt personnummer
+too.many.attempts=För många försök. Du måste vänta ett tag innan du får försöka igen
+
+

--- a/src/main/resources/templates/authenticator/freja-eid/authenticate/get.vm
+++ b/src/main/resources/templates/authenticator/freja-eid/authenticate/get.vm
@@ -14,6 +14,15 @@
 *  limitations under the License.
 *#
 
+#define($description)authenticator.freja-eid.authenticate.view.${userInfoType}.description#end
+#define($label)authenticator.freja-eid.authenticate.view.${userInfoType}.label#end
+#define($placeholder)authenticator.freja-eid.authenticate.view.${userInfoType}.placeholder#end
+#if ($userInfoType=='email')
+    #set($fielType = 'email')
+#else
+    #set($fielType = 'text')
+#end
+
 #define ($_body)
 
     #if ($_errors.toArray()[0]=='validation.error.username.required')
@@ -31,46 +40,25 @@
         $!error<br>
     </div>
 </div>
-    #if ($userInfoType=='ssn')
     <form id="usernameForm" method="post" action="$_authUrl">
 
         <div class="sm-col-12 center">
-            <h2>Get started</h2>
+            <h2>#message("authenticator.freja-eid.authenticate.view.title")</h2>
             <p>
-                Please enter your username
+                #message($description)
             </p>
         </div>
 
-        <label for="username" class="$!_errorClass">username</label>
-        <input type="text" id="username" name="username" class="block full-width mb1 field-light $!_errorClass"
+        <label for="username" class="$!_errorClass">#message($label)</label>
+        <input type="$fielType" id="username" name="username" class="block full-width mb1 field-light $!_errorClass"
                autocapitalize="none"
+               placeholder="#message($placeholder)"
                required
                value="$!username">
 
-        <button type="submit" class="button button-fullwidth button-primary">Next</button>
+        <button type="submit" class="button button-fullwidth button-primary">#message("authenticator.freja-eid.authenticate.view.submit")</button>
 
     </form>
-    #end
-    #if ($userInfoType=='email')
-    <form id="emailForm" method="post" action="$_authUrl">
-
-        <div class="sm-col-12 center">
-            <h2>Get started</h2>
-            <p>
-                Please enter your email
-            </p>
-        </div>
-
-        <label for="email" class="$!_errorClass">Email</label>
-        <input type="text" id="email" name="email" class="block full-width mb1 field-light $!_errorClass"
-               autocapitalize="none"
-               required
-               value="$!email">
-
-        <button type="submit" class="button button-fullwidth button-primary">Next</button>
-
-    </form>
-    #end
 #end
 
 #parse("layouts/default")

--- a/src/main/resources/templates/authenticator/freja-eid/authenticate/wait.vm
+++ b/src/main/resources/templates/authenticator/freja-eid/authenticate/wait.vm
@@ -20,9 +20,9 @@
 
 #define ($_body)
 <div class="sm-col-12 center">
-    <h2>Authorize App</h2>
+    <h2> #message("authenticator.freja-eid.authenticate.wait.view.title")</h2>
     <p>
-        Please open Freja e-ID mobile app and authorize the request.
+        #message("authenticator.freja-eid.authenticate.wait.view.description")
     </p>
 </div>
 <div class="center p2 loader">

--- a/src/main/resources/templates/authenticator/freja-eid/authenticate/wait.vm
+++ b/src/main/resources/templates/authenticator/freja-eid/authenticate/wait.vm
@@ -35,7 +35,7 @@
     <div class="center p2 loader">
         #parse("fragments/spinner")
     </div>
-    <form  name="cancel" id="cancel" action="$_action" method="post">
+    <form  name="cancel" id="cancel" class="manuallink display-none" action="$_action" method="post">
         <input type="hidden" name="cancel" value="true"/>
         <button type="submit" class="button button-fullwidth button-danger-outline" >#message("authenticator.freja-eid.authenticate.wait.cancel")</button>
     </form>
@@ -43,6 +43,11 @@
     <script type="text/javascript" $!nonceAttr>
         jQuery(document).ready(function () {
             document.forms["cancel"].onsubmit =se.curity.authenticator.polling.start();
+
+            // Wait 3 seconds, then show cancel
+            setTimeout(function () {
+                jQuery(".manuallink").removeClass("display-none");
+            }, 3000);
         });
     </script>
     #end

--- a/src/main/resources/templates/authenticator/freja-eid/authenticate/wait.vm
+++ b/src/main/resources/templates/authenticator/freja-eid/authenticate/wait.vm
@@ -25,15 +25,27 @@
         #message("authenticator.freja-eid.authenticate.wait.view.description")
     </p>
 </div>
-<div class="center p2 loader">
-    #parse("fragments/spinner")
-</div>
+
 
 <form id="pollingForm" action="$_action" method="post">
     <input type="hidden" name="moveOn" value="true"/>
 </form>
 
-    #parse("fragments/poller")
+    #if(!$!_errors)
+    <div class="center p2 loader">
+        #parse("fragments/spinner")
+    </div>
+    <form id="cancelForm" action="$_action" method="post">
+        <input type="hidden" name="cancel" value="true"/>
+        <button type="submit" class="button button-fullwidth button-danger-outline" >#message("authenticator.freja-eid.authenticate.wait.cancel")</button>
+    </form>
+        #parse("fragments/poller")
+    #end
+
+<div class="center py2 login-actions">
+    <a href="$_authUrl" role="button">
+        <i class="icon ion-refresh inlineicon"></i>#message("authenticator.freja-eid.authenticate.wait.back")</a>
+</div>
 #end
 
 #parse("layouts/default")

--- a/src/main/resources/templates/authenticator/freja-eid/authenticate/wait.vm
+++ b/src/main/resources/templates/authenticator/freja-eid/authenticate/wait.vm
@@ -27,7 +27,7 @@
 </div>
 
 
-<form id="pollingForm" action="$_action" method="post">
+<form id="pollingDone" action="$_action" method="post">
     <input type="hidden" name="moveOn" value="true"/>
 </form>
 
@@ -35,11 +35,16 @@
     <div class="center p2 loader">
         #parse("fragments/spinner")
     </div>
-    <form id="cancelForm" action="$_action" method="post">
+    <form  name="cancel" id="cancel" action="$_action" method="post">
         <input type="hidden" name="cancel" value="true"/>
         <button type="submit" class="button button-fullwidth button-danger-outline" >#message("authenticator.freja-eid.authenticate.wait.cancel")</button>
     </form>
-        #parse("fragments/poller")
+        #parse("fragments/generic-poller")
+    <script type="text/javascript" $!nonceAttr>
+        jQuery(document).ready(function () {
+            document.forms["cancel"].onsubmit =se.curity.authenticator.polling.start();
+        });
+    </script>
     #end
 
 <div class="center py2 login-actions">


### PR DESCRIPTION
- Fixed an issue caused by json encoding of a base64 encoded string, which was not accepted by Freja API
- Unified the template and added support for swedish language
- Added the possibility to login using phoneNumber
- Added configuration option to set the minimum required registration level
- Added configuration option to select which attributes to be returned by Freja API
- Added support for Cancel
