### PR TITLE
Changes the qrcode and local app start links

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.curityVersion>5.4.0</project.curityVersion>
+        <project.curityVersion>6.0.0-20210122.154552-2</project.curityVersion>
         <project.slf4jVersion>1.7.25</project.slf4jVersion>
         <kotlin.version>1.3.72</kotlin.version>
     </properties>
@@ -31,12 +31,16 @@
                     <execution>
                         <id>compile</id>
                         <phase>compile</phase>
-                        <goals><goal>compile</goal></goals>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
                     </execution>
                     <execution>
                         <id>test-compile</id>
                         <phase>test-compile</phase>
-                        <goals><goal>test-compile</goal></goals>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
                     </execution>
                 </executions>
                 <configuration>
@@ -77,4 +81,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <repositories>
+
+        <!-- to allow using snapshot versions of the server SDK -->
+        <repository>
+            <id>customer-snapshot-repo</id>
+            <url>https://nexus.curity.se/nexus/content/repositories/customer-snapshot-repo</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/authentication/representationFunctions.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/frejaeid/authentication/representationFunctions.kt
@@ -1,7 +1,6 @@
 package io.curity.identityserver.plugin.frejaeid.authentication
 
 import se.curity.identityserver.sdk.haapi.*
-import se.curity.identityserver.sdk.haapi.HaapiContract.Links.Relations.QR_CODE
 import se.curity.identityserver.sdk.http.HttpMethod
 import se.curity.identityserver.sdk.http.MediaType
 import se.curity.identityserver.sdk.web.LinkRelation
@@ -54,7 +53,8 @@ class WaitRepresentationFunction : RepresentationFunction
     {
         val cancelMessage: Message = Message.ofKey("wait.cancel")
         val thisDeviceMessage: Message = Message.ofKey("view.this-device")
-
+        val scanQrCode: Message = Message.ofKey("view.scan-qrcode")
+        val startAppLinkRelation: LinkRelation = LinkRelation.of("app-start")
     }
     override fun apply(model: RepresentationModel, factory: RepresentationFactory): Representation
     {
@@ -74,8 +74,8 @@ class WaitRepresentationFunction : RepresentationFunction
             val qrCode = model.getOptionalString("_qrCode")
             factory.newPollingStep().pending { step ->
                 if (qrCode.isPresent && thisDeviceLink.isPresent) {
-                    step.addLink(URI.create(thisDeviceLink.get()), LinkRelation.of("this-device"), thisDeviceMessage)
-                    step.addLink(URI.create(qrCode.get()), QR_CODE)
+                    step.addLink(URI.create(thisDeviceLink.get()), startAppLinkRelation, thisDeviceMessage)
+                    step.addLink(URI.create(qrCode.get()), startAppLinkRelation, scanQrCode, MediaType.IMAGE_PNG)
                 }
                 step.setPollFormAction(action, HttpMethod.POST, MediaType.X_WWW_FORM_URLENCODED, null, Actions.EMPTY_CONSUMER)
                 step.setCancelFormAction(action, HttpMethod.POST, MediaType.X_WWW_FORM_URLENCODED,


### PR DESCRIPTION
Changes the qrcode and local app start links, namely because the `qrcode` relation was deprecated.
Also uses the same rel in the two links: open locally and open via qrcode since IMO they are both used to start the app.